### PR TITLE
Implement minimal metadata tables

### DIFF
--- a/Il2CppMetaForge/build.sh
+++ b/Il2CppMetaForge/build.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 echo "[*] 빌드 디렉토리 생성 중..."
 mkdir -p build
 cd build

--- a/Il2CppMetaForge/include/MetadataBuilder.h
+++ b/Il2CppMetaForge/include/MetadataBuilder.h
@@ -13,7 +13,9 @@ public:
     void SetMethodDefinitions(const std::vector<Il2CppMethodDefinition>& defs);
     void SetStringLiterals(const std::vector<Il2CppStringLiteral>& literals,
                            const std::vector<char>& stringData);
+    void SetStrings(const std::vector<char>& strings);
     void SetMetadataUsages(const std::vector<Il2CppMetadataUsage>& usages);
+    void SetImageDefinitions(const std::vector<Il2CppImageDefinition>& images);
 
     void Build();
 
@@ -22,6 +24,7 @@ private:
     void WriteTypeDefinitions(std::ofstream& file);
     void WriteMethodDefinitions(std::ofstream& file);
     void WriteStringLiteralTable(std::ofstream& file);
+    void WriteStringTable(std::ofstream& file);
     void WriteMetadataUsages(std::ofstream& file);
     void WriteImageDefinitions(std::ofstream& file);
 
@@ -30,6 +33,8 @@ private:
     std::vector<Il2CppMethodDefinition> methodDefinitions;
     std::vector<Il2CppStringLiteral> stringLiterals;
     std::vector<char> stringLiteralData;
+    std::vector<char> strings;
     std::vector<Il2CppMetadataUsage> metadataUsages;
+    std::vector<Il2CppImageDefinition> imageDefinitions;
 };
 

--- a/Il2CppMetaForge/src/MetadataBuilder.cpp
+++ b/Il2CppMetaForge/src/MetadataBuilder.cpp
@@ -21,9 +21,19 @@ void MetadataBuilder::SetStringLiterals(const std::vector<Il2CppStringLiteral>& 
     stringLiteralData = stringData;
 }
 
+void MetadataBuilder::SetStrings(const std::vector<char>& strs)
+{
+    strings = strs;
+}
+
 void MetadataBuilder::SetMetadataUsages(const std::vector<Il2CppMetadataUsage>& usages)
 {
     metadataUsages = usages;
+}
+
+void MetadataBuilder::SetImageDefinitions(const std::vector<Il2CppImageDefinition>& images)
+{
+    imageDefinitions = images;
 }
 
 void MetadataBuilder::Build()
@@ -33,9 +43,10 @@ void MetadataBuilder::Build()
         return;
 
     WriteMetadataHeader(file);
-    WriteTypeDefinitions(file);
-    WriteMethodDefinitions(file);
     WriteStringLiteralTable(file);
+    WriteStringTable(file);
+    WriteMethodDefinitions(file);
+    WriteTypeDefinitions(file);
     WriteMetadataUsages(file);
     WriteImageDefinitions(file);
 
@@ -47,8 +58,25 @@ void MetadataBuilder::WriteMetadataHeader(std::ofstream& file)
     Il2CppGlobalMetadataHeader header{};
     header.sanity = 0xFAB11BAF;
     header.version = 31;
-    header.stringLiteralOffset = sizeof(Il2CppGlobalMetadataHeader);
+
+    uint32_t offset = sizeof(Il2CppGlobalMetadataHeader);
+    header.stringLiteralOffset = offset;
     header.stringLiteralCount = static_cast<uint32_t>(stringLiterals.size());
+    offset += static_cast<uint32_t>(stringLiterals.size() * sizeof(Il2CppStringLiteral) +
+                                   stringLiteralData.size());
+
+    header.stringOffset = offset;
+    header.stringCount = static_cast<uint32_t>(strings.size());
+    offset += static_cast<uint32_t>(strings.size());
+
+    header.methodDefinitionOffset = offset;
+    header.methodDefinitionCount = static_cast<uint32_t>(methodDefinitions.size());
+    offset += static_cast<uint32_t>(methodDefinitions.size() * sizeof(Il2CppMethodDefinition));
+
+    header.typeDefinitionOffset = offset;
+    header.typeDefinitionCount = static_cast<uint32_t>(typeDefinitions.size());
+    offset += static_cast<uint32_t>(typeDefinitions.size() * sizeof(Il2CppTypeDefinition));
+
     file.write(reinterpret_cast<const char*>(&header), sizeof(header));
 }
 
@@ -72,6 +100,11 @@ void MetadataBuilder::WriteStringLiteralTable(std::ofstream& file)
     file.write(stringLiteralData.data(), stringLiteralData.size());
 }
 
+void MetadataBuilder::WriteStringTable(std::ofstream& file)
+{
+    file.write(strings.data(), strings.size());
+}
+
 void MetadataBuilder::WriteMetadataUsages(std::ofstream& file)
 {
     for (const auto& usage : metadataUsages)
@@ -80,6 +113,7 @@ void MetadataBuilder::WriteMetadataUsages(std::ofstream& file)
 
 void MetadataBuilder::WriteImageDefinitions(std::ofstream& file)
 {
-    // Placeholder for image definitions output
+    for (const auto& img : imageDefinitions)
+        file.write(reinterpret_cast<const char*>(&img), sizeof(img));
 }
 

--- a/Il2CppMetaForge/src/main.cpp
+++ b/Il2CppMetaForge/src/main.cpp
@@ -1,9 +1,19 @@
-﻿#include <iostream>
+#include <iostream>
+#include <vector>
+#include <cstring>
 #include "MemoryReader.h"
 #include "MetadataBuilder.h"
 
-int main()
+int main(int argc, char* argv[])
 {
+    if (argc < 2)
+    {
+        std::cerr << "Usage: Il2CppMetaForge <GameAssembly.dll path>" << std::endl;
+        return 1;
+    }
+
+    const char* dllPath = argv[1];
+
     uintptr_t imageBase = 0x140000000;
     uintptr_t dataSectionVA = 0x000000018D461A80;
     uint64_t dataFileOffset = 0x02100000;
@@ -13,7 +23,7 @@ int main()
     const std::string outputPath = "global-metadata.dat";
     MetadataBuilder builder(outputPath);
 
-    std::ifstream gameAssembly("test/mabinogi/GameAssembly.dll", std::ios::binary);
+    std::ifstream gameAssembly(dllPath, std::ios::binary);
     if (!gameAssembly)
     {
         std::cerr << "GameAssembly.dll open failed" << std::endl;
@@ -21,6 +31,51 @@ int main()
     }
 
     reader.LoadMetadataPointers(gameAssembly);
+
+    // \uAE30\uBCF8 \uAD6C\uC870\uCCB4 \uC124\uC815
+    std::vector<char> stringTable;
+    const char* names[] = {"Assembly-CSharp", "MyClass", "Utils", "Foo"};
+    for (const char* n : names)
+    {
+        size_t len = std::strlen(n);
+        stringTable.insert(stringTable.end(), n, n + len + 1);
+    }
+
+    std::vector<Il2CppImageDefinition> images(1);
+    images[0] = {};
+    images[0].nameIndex = 0;      // "Assembly-CSharp"
+    images[0].typeStart = 0;
+    images[0].typeCount = 1;
+
+    std::vector<Il2CppTypeDefinition> types(1);
+    types[0] = {};
+    types[0].nameIndex = 1;        // "MyClass"
+    types[0].namespaceIndex = 2;   // "Utils"
+    types[0].methodStart = 0;
+    types[0].method_count = 1;
+
+    std::vector<Il2CppMethodDefinition> methods(1);
+    methods[0] = {};
+    methods[0].nameIndex = 3;      // "Foo"
+    methods[0].declaringType = 0;
+    methods[0].returnType = 0;
+    methods[0].parameterCount = 0;
+
+    std::vector<Il2CppStringLiteral> literals(1);
+    literals[0].length = 4;
+    literals[0].dataIndex = 0;
+
+    std::vector<char> literalData = {'T', 'e', 's', 't', '\0'};
+
+    std::vector<Il2CppMetadataUsage> usages(1);
+
+    builder.SetTypeDefinitions(types);
+    builder.SetMethodDefinitions(methods);
+    builder.SetStringLiterals(literals, literalData);
+    builder.SetStrings(stringTable);
+    builder.SetMetadataUsages(usages);
+    builder.SetImageDefinitions(images);
+
     builder.Build();
 
     std::cout << "metadata build complete" << std::endl;


### PR DESCRIPTION
## Summary
- support writing string table for metadata names
- store image, type, and method definitions with proper indices
- inject minimal string and struct data in main for building metadata

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865a8a083608332907079f9090cdc87