### PR TITLE
메모리 포인터 활용 로직 추가

### DIFF
--- a/Il2CppMetaForge/include/MemoryReader.h
+++ b/Il2CppMetaForge/include/MemoryReader.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <vector>
 
 class MemoryReader {
 public:
@@ -23,6 +24,9 @@ public:
     template <typename T>
     T ReadStruct(std::ifstream& file, uint64_t fileOffset);
 
+    template <typename T>
+    std::vector<T> ReadStructArray(std::ifstream& file, uint64_t fileOffset, size_t count);
+
 private:
     uintptr_t baseVirtualAddress{0};
     uintptr_t dataVirtualAddress{0};
@@ -43,5 +47,14 @@ T MemoryReader::ReadStruct(std::ifstream& file, uint64_t fileOffset)
     file.seekg(fileOffset, std::ios::beg);
     file.read(reinterpret_cast<char*>(&value), sizeof(T));
     return value;
+}
+
+template <typename T>
+std::vector<T> MemoryReader::ReadStructArray(std::ifstream& file, uint64_t fileOffset, size_t count)
+{
+    std::vector<T> values(count);
+    file.seekg(fileOffset, std::ios::beg);
+    file.read(reinterpret_cast<char*>(values.data()), sizeof(T) * count);
+    return values;
 }
 


### PR DESCRIPTION
## Summary
- MemoryReader에 배열 읽기 함수 추가
- main.cpp에서 실제 메모리 구조체를 읽어 MetadataBuilder에 주입
- 빌드 스크립트 실행으로 컴파일 검증

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865d33e9c708332ab351d332260b1d5