### PR TITLE
확장된 Il2CppGlobalMetadataHeader 적용

### DIFF
--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.h
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.h
@@ -57,26 +57,84 @@ struct Il2CppStringLiteral
 struct Il2CppGlobalMetadataHeader
 {
     uint32_t sanity;
-    int32_t version;
+    int32_t  version;
 
     uint32_t stringLiteralOffset;
-    uint32_t stringLiteralCount;
+    int32_t  stringLiteralSize;
+    uint32_t stringLiteralDataOffset;
+    int32_t  stringLiteralDataSize;
 
     uint32_t stringOffset;
-    uint32_t stringCount;
+    int32_t  stringSize;
 
-    uint32_t methodDefinitionOffset;
-    uint32_t methodDefinitionCount;
+    uint32_t eventsOffset;
+    int32_t  eventsSize;
+    uint32_t propertiesOffset;
+    int32_t  propertiesSize;
+    uint32_t methodsOffset;
+    int32_t  methodsSize;
 
-    uint32_t typeDefinitionOffset;
-    uint32_t typeDefinitionCount;
+    uint32_t parameterDefaultValuesOffset;
+    int32_t  parameterDefaultValuesSize;
+    uint32_t fieldDefaultValuesOffset;
+    int32_t  fieldDefaultValuesSize;
+    uint32_t fieldAndParameterDefaultValueDataOffset;
+    int32_t  fieldAndParameterDefaultValueDataSize;
+    int32_t  fieldMarshaledSizesOffset;
+    int32_t  fieldMarshaledSizesSize;
 
-    uint32_t metadataUsageOffset;
-    uint32_t metadataUsageCount;
-
-    uint32_t imageDefinitionOffset;
-    uint32_t imageDefinitionCount;
-    // reserved for future use
+    uint32_t parametersOffset;
+    int32_t  parametersSize;
+    uint32_t fieldsOffset;
+    int32_t  fieldsSize;
+    uint32_t genericParametersOffset;
+    int32_t  genericParametersSize;
+    uint32_t genericParameterConstraintsOffset;
+    int32_t  genericParameterConstraintsSize;
+    uint32_t genericContainersOffset;
+    int32_t  genericContainersSize;
+    uint32_t nestedTypesOffset;
+    int32_t  nestedTypesSize;
+    uint32_t interfacesOffset;
+    int32_t  interfacesSize;
+    uint32_t vtableMethodsOffset;
+    int32_t  vtableMethodsSize;
+    int32_t  interfaceOffsetsOffset;
+    int32_t  interfaceOffsetsSize;
+    uint32_t typeDefinitionsOffset;
+    int32_t  typeDefinitionsSize;
+    uint32_t rgctxEntriesOffset;
+    int32_t  rgctxEntriesCount;
+    uint32_t imagesOffset;
+    int32_t  imagesSize;
+    uint32_t assembliesOffset;
+    int32_t  assembliesSize;
+    uint32_t metadataUsageListsOffset;
+    int32_t  metadataUsageListsCount;
+    uint32_t metadataUsagePairsOffset;
+    int32_t  metadataUsagePairsCount;
+    uint32_t fieldRefsOffset;
+    int32_t  fieldRefsSize;
+    int32_t  referencedAssembliesOffset;
+    int32_t  referencedAssembliesSize;
+    uint32_t attributesInfoOffset;
+    int32_t  attributesInfoCount;
+    uint32_t attributeTypesOffset;
+    int32_t  attributeTypesCount;
+    uint32_t attributeDataOffset;
+    int32_t  attributeDataSize;
+    uint32_t attributeDataRangeOffset;
+    int32_t  attributeDataRangeSize;
+    int32_t  unresolvedVirtualCallParameterTypesOffset;
+    int32_t  unresolvedVirtualCallParameterTypesSize;
+    int32_t  unresolvedVirtualCallParameterRangesOffset;
+    int32_t  unresolvedVirtualCallParameterRangesSize;
+    int32_t  windowsRuntimeTypeNamesOffset;
+    int32_t  windowsRuntimeTypeNamesSize;
+    int32_t  windowsRuntimeStringsOffset;
+    int32_t  windowsRuntimeStringsSize;
+    int32_t  exportedTypeDefinitionsOffset;
+    int32_t  exportedTypeDefinitionsSize;
 };
 
 struct Il2CppMetadataUsage

--- a/Il2CppMetaForge/src/MetadataBuilder.cpp
+++ b/Il2CppMetaForge/src/MetadataBuilder.cpp
@@ -56,34 +56,104 @@ void MetadataBuilder::Build()
 void MetadataBuilder::WriteMetadataHeader(std::ofstream& file)
 {
     Il2CppGlobalMetadataHeader header{};
-    header.sanity = 0xFAB11BAF;
+    header.sanity  = 0xFAB11BAF;
     header.version = 31;
 
     uint32_t offset = sizeof(Il2CppGlobalMetadataHeader);
     header.stringLiteralOffset = offset;
-    header.stringLiteralCount = static_cast<uint32_t>(stringLiterals.size());
-    offset += static_cast<uint32_t>(stringLiterals.size() * sizeof(Il2CppStringLiteral) +
-                                   stringLiteralData.size());
+    header.stringLiteralSize   = static_cast<int32_t>(stringLiterals.size() * sizeof(Il2CppStringLiteral));
+    offset += header.stringLiteralSize;
+
+    header.stringLiteralDataOffset = offset;
+    header.stringLiteralDataSize   = static_cast<int32_t>(stringLiteralData.size());
+    offset += header.stringLiteralDataSize;
 
     header.stringOffset = offset;
-    header.stringCount = static_cast<uint32_t>(strings.size());
-    offset += static_cast<uint32_t>(strings.size());
+    header.stringSize   = static_cast<int32_t>(strings.size());
+    offset += header.stringSize;
 
-    header.methodDefinitionOffset = offset;
-    header.methodDefinitionCount = static_cast<uint32_t>(methodDefinitions.size());
-    offset += static_cast<uint32_t>(methodDefinitions.size() * sizeof(Il2CppMethodDefinition));
+    header.eventsOffset    = 0;
+    header.eventsSize      = 0;
+    header.propertiesOffset = 0;
+    header.propertiesSize   = 0;
 
-    header.typeDefinitionOffset = offset;
-    header.typeDefinitionCount = static_cast<uint32_t>(typeDefinitions.size());
-    offset += static_cast<uint32_t>(typeDefinitions.size() * sizeof(Il2CppTypeDefinition));
+    header.methodsOffset = offset;
+    header.methodsSize   = static_cast<int32_t>(methodDefinitions.size() * sizeof(Il2CppMethodDefinition));
+    offset += header.methodsSize;
 
-    header.metadataUsageOffset = offset;
-    header.metadataUsageCount = static_cast<uint32_t>(metadataUsages.size());
+    header.parameterDefaultValuesOffset        = 0;
+    header.parameterDefaultValuesSize          = 0;
+    header.fieldDefaultValuesOffset            = 0;
+    header.fieldDefaultValuesSize              = 0;
+    header.fieldAndParameterDefaultValueDataOffset = 0;
+    header.fieldAndParameterDefaultValueDataSize   = 0;
+    header.fieldMarshaledSizesOffset           = 0;
+    header.fieldMarshaledSizesSize             = 0;
+
+    header.parametersOffset                   = 0;
+    header.parametersSize                     = 0;
+    header.fieldsOffset                       = 0;
+    header.fieldsSize                         = 0;
+    header.genericParametersOffset            = 0;
+    header.genericParametersSize              = 0;
+    header.genericParameterConstraintsOffset  = 0;
+    header.genericParameterConstraintsSize    = 0;
+    header.genericContainersOffset            = 0;
+    header.genericContainersSize              = 0;
+    header.nestedTypesOffset                  = 0;
+    header.nestedTypesSize                    = 0;
+    header.interfacesOffset                   = 0;
+    header.interfacesSize                     = 0;
+    header.vtableMethodsOffset                = 0;
+    header.vtableMethodsSize                  = 0;
+    header.interfaceOffsetsOffset             = 0;
+    header.interfaceOffsetsSize               = 0;
+
+    header.typeDefinitionsOffset = offset;
+    header.typeDefinitionsSize   = static_cast<int32_t>(typeDefinitions.size() * sizeof(Il2CppTypeDefinition));
+    offset += header.typeDefinitionsSize;
+
+    header.rgctxEntriesOffset = 0;
+    header.rgctxEntriesCount  = 0;
+
+    header.imagesOffset = 0; // temporary, actual value set later
+    header.imagesSize   = 0;
+
+    header.assembliesOffset = 0;
+    header.assembliesSize   = 0;
+
+    header.metadataUsageListsOffset = 0;
+    header.metadataUsageListsCount  = 0;
+    header.metadataUsagePairsOffset = offset;
+    header.metadataUsagePairsCount  = static_cast<int32_t>(metadataUsages.size());
     offset += static_cast<uint32_t>(metadataUsages.size() * sizeof(Il2CppMetadataUsage));
 
-    header.imageDefinitionOffset = offset;
-    header.imageDefinitionCount = static_cast<uint32_t>(imageDefinitions.size());
-    offset += static_cast<uint32_t>(imageDefinitions.size() * sizeof(Il2CppImageDefinition));
+    header.fieldRefsOffset           = 0;
+    header.fieldRefsSize             = 0;
+    header.referencedAssembliesOffset = 0;
+    header.referencedAssembliesSize   = 0;
+    header.attributesInfoOffset       = 0;
+    header.attributesInfoCount        = 0;
+    header.attributeTypesOffset       = 0;
+    header.attributeTypesCount        = 0;
+    header.attributeDataOffset        = 0;
+    header.attributeDataSize          = 0;
+    header.attributeDataRangeOffset   = 0;
+    header.attributeDataRangeSize     = 0;
+    header.unresolvedVirtualCallParameterTypesOffset  = 0;
+    header.unresolvedVirtualCallParameterTypesSize    = 0;
+    header.unresolvedVirtualCallParameterRangesOffset = 0;
+    header.unresolvedVirtualCallParameterRangesSize   = 0;
+    header.windowsRuntimeTypeNamesOffset  = 0;
+    header.windowsRuntimeTypeNamesSize    = 0;
+    header.windowsRuntimeStringsOffset    = 0;
+    header.windowsRuntimeStringsSize      = 0;
+    header.exportedTypeDefinitionsOffset  = 0;
+    header.exportedTypeDefinitionsSize    = 0;
+
+    header.imagesOffset = offset;
+    header.imagesSize   = static_cast<int32_t>(imageDefinitions.size() * sizeof(Il2CppImageDefinition));
+    offset += header.imagesSize;
 
     file.write(reinterpret_cast<const char*>(&header), sizeof(header));
 }


### PR DESCRIPTION
## 요약
- Il2Cpp v31 기준 `Il2CppGlobalMetadataHeader` 전체 필드 정의 추가
- 메타데이터 헤더 작성 로직을 새로운 구조체에 맞게 수정

## 테스트
- `build.sh` 실행하여 빌드 완료
- `ctest` 실행 (테스트 없음 확인)

------
https://chatgpt.com/codex/tasks/task_e_6865d8fca4808332852107ff67e66d9b