### PR TITLE
Remove BOMs from source files

### DIFF
--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.h
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <cstdint>
 #include <vector>

--- a/Il2CppMetaForge/include/MemoryReader.h
+++ b/Il2CppMetaForge/include/MemoryReader.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <cstdint>
 #include <fstream>

--- a/Il2CppMetaForge/include/MetadataBuilder.h
+++ b/Il2CppMetaForge/include/MetadataBuilder.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "Il2CppMetadataStructs.h"
 #include <string>

--- a/Il2CppMetaForge/src/MemoryReader.cpp
+++ b/Il2CppMetaForge/src/MemoryReader.cpp
@@ -1,4 +1,4 @@
-﻿// MemoryReader.cpp
+// MemoryReader.cpp
 #include "MemoryReader.h"
 #include <iostream>
 #include <fstream>

--- a/Il2CppMetaForge/src/MetadataBuilder.cpp
+++ b/Il2CppMetaForge/src/MetadataBuilder.cpp
@@ -1,4 +1,4 @@
-﻿#include "MetadataBuilder.h"
+#include "MetadataBuilder.h"
 #include <cstring>
 
 MetadataBuilder::MetadataBuilder(const std::string& path)


### PR DESCRIPTION
## Summary
- remove byte order marks from C++ headers and sources so files are UTF-8 without BOM

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6865e243d6c48332aae4e268f9a1b102