### PR TITLE
Add field and property metadata handling

### DIFF
--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.h
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.h
@@ -88,6 +88,12 @@ struct Il2CppGlobalMetadataHeader
     uint32_t methodDefinitionOffset;
     uint32_t methodDefinitionCount;
 
+    uint32_t fieldDefinitionOffset;
+    uint32_t fieldDefinitionCount;
+
+    uint32_t propertyDefinitionOffset;
+    uint32_t propertyDefinitionCount;
+
     uint32_t typeDefinitionOffset;
     uint32_t typeDefinitionCount;
 

--- a/Il2CppMetaForge/src/MetadataBuilder.cpp
+++ b/Il2CppMetaForge/src/MetadataBuilder.cpp
@@ -57,6 +57,8 @@ void MetadataBuilder::Build()
     WriteStringLiteralData(file);
     WriteStringTable(file);
     WriteMethodDefinitions(file);
+    WriteFieldDefinitions(file);
+    WritePropertyDefinitions(file);
     WriteTypeDefinitions(file);
     WriteMetadataUsages(file);
     WriteImageDefinitions(file);
@@ -86,6 +88,14 @@ void MetadataBuilder::WriteMetadataHeader(std::ofstream& file)
     header.methodDefinitionOffset = offset;
     header.methodDefinitionCount = static_cast<uint32_t>(methodDefinitions.size());
     offset += static_cast<uint32_t>(methodDefinitions.size() * sizeof(Il2CppMethodDefinition));
+
+    header.fieldDefinitionOffset = offset;
+    header.fieldDefinitionCount = static_cast<uint32_t>(fieldDefinitions.size());
+    offset += static_cast<uint32_t>(fieldDefinitions.size() * sizeof(Il2CppFieldDefinition));
+
+    header.propertyDefinitionOffset = offset;
+    header.propertyDefinitionCount = static_cast<uint32_t>(propertyDefinitions.size());
+    offset += static_cast<uint32_t>(propertyDefinitions.size() * sizeof(Il2CppPropertyDefinition));
 
     header.typeDefinitionOffset = offset;
     header.typeDefinitionCount = static_cast<uint32_t>(typeDefinitions.size());


### PR DESCRIPTION
## Summary
- metadata 빌더에서 필드와 프로퍼티 테이블도 작성하도록 수정
- 메타데이터 헤더에 필드/프로퍼티 오프셋과 개수 항목 추가

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686640910f448332ad8fde244126f7c9