### PR TITLE
Implement direct metadata count loading

### DIFF
--- a/Il2CppMetaForge/include/MemoryReader.h
+++ b/Il2CppMetaForge/include/MemoryReader.h
@@ -16,17 +16,17 @@ public:
     uintptr_t GetTypeDefinitions() const;
     uintptr_t GetMethodDefinitions() const;
     uintptr_t GetStringLiteralTable() const;
-    uintptr_t GetStringLiteralTableCount() const;
+    uint32_t GetStringLiteralTableCount() const;
     uintptr_t GetMetadataUsages() const;
-    uintptr_t GetMetadataUsagesCount() const;
-    uintptr_t GetImageDefinitionsCount() const;
+    uint32_t GetMetadataUsagesCount() const;
+    uint32_t GetImageDefinitionsCount() const;
     uintptr_t GetFieldDefinitions() const;
-    uintptr_t GetFieldDefinitionsCount() const;
+    uint32_t GetFieldDefinitionsCount() const;
     uintptr_t GetPropertyDefinitions() const;
-    uintptr_t GetPropertyDefinitionsCount() const;
+    uint32_t GetPropertyDefinitionsCount() const;
 
-    uintptr_t GetTypeDefinitionsCount() const;
-    uintptr_t GetMethodDefinitionsCount() const;
+    uint32_t GetTypeDefinitionsCount() const;
+    uint32_t GetMethodDefinitionsCount() const;
 
     uintptr_t ReadPointer(std::ifstream& file, uint64_t fileOffset);
     template <typename T>
@@ -45,18 +45,18 @@ private:
     uintptr_t typeDefinitions{0};
     uintptr_t methodDefinitions{0};
     uintptr_t stringLiteralTable{0};
-    uintptr_t stringLiteralTableCount{0};
+    uint32_t stringLiteralTableCount{0};
     uintptr_t metadataUsages{0};
-    uintptr_t metadataUsagesCount{0};
-    uintptr_t imageDefinitionsCount{0};
-    uintptr_t typeDefinitionsCount{0};
-    uintptr_t methodDefinitionsCount{0};
+    uint32_t metadataUsagesCount{0};
+    uint32_t imageDefinitionsCount{0};
+    uint32_t typeDefinitionsCount{0};
+    uint32_t methodDefinitionsCount{0};
 
     // 필드와 프로퍼티 정의 데이터 포인터와 개수
     uintptr_t fieldDefinitions{0};
-    uintptr_t fieldDefinitionsCount{0};
+    uint32_t fieldDefinitionsCount{0};
     uintptr_t propertyDefinitions{0};
-    uintptr_t propertyDefinitionsCount{0};
+    uint32_t propertyDefinitionsCount{0};
 };
 
 template <typename T>

--- a/Il2CppMetaForge/src/MemoryReader.cpp
+++ b/Il2CppMetaForge/src/MemoryReader.cpp
@@ -34,28 +34,28 @@ void MemoryReader::LoadMetadataPointers(std::ifstream& file)
     typeDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461A90));
     methodDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461A98));
     stringLiteralTable = ReadPointer(file, RvaToFileOffset(0x18D461AA0));
-    stringLiteralTableCount = ReadPointer(file, RvaToFileOffset(0x18D461AA8));
-    typeDefinitionsCount = ReadPointer(file, RvaToFileOffset(0x18D461AB0));
-    methodDefinitionsCount = ReadPointer(file, RvaToFileOffset(0x18D461AB8));
+    stringLiteralTableCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AA8));
+    typeDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AB0));
+    methodDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AB8));
     fieldDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461AC0));
-    fieldDefinitionsCount = ReadPointer(file, RvaToFileOffset(0x18D461AC8));
+    fieldDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AC8));
     propertyDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461AD0));
-    propertyDefinitionsCount = ReadPointer(file, RvaToFileOffset(0x18D461AD8));
+    propertyDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AD8));
     metadataUsages = ReadPointer(file, RvaToFileOffset(0x18D461AE0));
-    metadataUsagesCount = ReadPointer(file, RvaToFileOffset(0x18D461AE8));
-    imageDefinitionsCount = ReadPointer(file, RvaToFileOffset(0x18D461AF0));
+    metadataUsagesCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AE8));
+    imageDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AF0));
 }
 
 uintptr_t MemoryReader::GetTypeDefinitions() const { return typeDefinitions; }
 uintptr_t MemoryReader::GetMethodDefinitions() const { return methodDefinitions; }
 uintptr_t MemoryReader::GetStringLiteralTable() const { return stringLiteralTable; }
-uintptr_t MemoryReader::GetStringLiteralTableCount() const { return stringLiteralTableCount; }
+uint32_t MemoryReader::GetStringLiteralTableCount() const { return stringLiteralTableCount; }
 uintptr_t MemoryReader::GetMetadataUsages() const { return metadataUsages; }
-uintptr_t MemoryReader::GetMetadataUsagesCount() const { return metadataUsagesCount; }
-uintptr_t MemoryReader::GetImageDefinitionsCount() const { return imageDefinitionsCount; }
+uint32_t MemoryReader::GetMetadataUsagesCount() const { return metadataUsagesCount; }
+uint32_t MemoryReader::GetImageDefinitionsCount() const { return imageDefinitionsCount; }
 uintptr_t MemoryReader::GetFieldDefinitions() const { return fieldDefinitions; }
-uintptr_t MemoryReader::GetFieldDefinitionsCount() const { return fieldDefinitionsCount; }
+uint32_t MemoryReader::GetFieldDefinitionsCount() const { return fieldDefinitionsCount; }
 uintptr_t MemoryReader::GetPropertyDefinitions() const { return propertyDefinitions; }
-uintptr_t MemoryReader::GetPropertyDefinitionsCount() const { return propertyDefinitionsCount; }
-uintptr_t MemoryReader::GetTypeDefinitionsCount() const { return typeDefinitionsCount; }
-uintptr_t MemoryReader::GetMethodDefinitionsCount() const { return methodDefinitionsCount; }
+uint32_t MemoryReader::GetPropertyDefinitionsCount() const { return propertyDefinitionsCount; }
+uint32_t MemoryReader::GetTypeDefinitionsCount() const { return typeDefinitionsCount; }
+uint32_t MemoryReader::GetMethodDefinitionsCount() const { return methodDefinitionsCount; }

--- a/Il2CppMetaForge/src/MemoryReader.md
+++ b/Il2CppMetaForge/src/MemoryReader.md
@@ -12,16 +12,16 @@
 typeDefinitions         = ReadPointer(file, RvaToFileOffset(0x18D461A90));  // -> typeDefinitions
 methodDefinitions       = ReadPointer(file, RvaToFileOffset(0x18D461A98));  // -> methodDefinitions
 stringLiteralTable      = ReadPointer(file, RvaToFileOffset(0x18D461AA0));  // -> stringLiteralTable
-stringLiteralTableCount = ReadPointer(file, RvaToFileOffset(0x18D461AA8));  // -> stringLiteralTableCount
-typeDefinitionsCount    = ReadPointer(file, RvaToFileOffset(0x18D461AB0));  // -> typeDefinitionsCount
-methodDefinitionsCount  = ReadPointer(file, RvaToFileOffset(0x18D461AB8));  // -> methodDefinitionsCount
+stringLiteralTableCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AA8));  // -> stringLiteralTableCount
+typeDefinitionsCount    = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AB0));  // -> typeDefinitionsCount
+methodDefinitionsCount  = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AB8));  // -> methodDefinitionsCount
 fieldDefinitions        = ReadPointer(file, RvaToFileOffset(0x18D461AC0));  // -> fieldDefinitions
-fieldDefinitionsCount   = ReadPointer(file, RvaToFileOffset(0x18D461AC8));  // -> fieldDefinitionsCount
+fieldDefinitionsCount   = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AC8));  // -> fieldDefinitionsCount
 propertyDefinitions     = ReadPointer(file, RvaToFileOffset(0x18D461AD0));  // -> propertyDefinitions
-propertyDefinitionsCount= ReadPointer(file, RvaToFileOffset(0x18D461AD8));  // -> propertyDefinitionsCount
+propertyDefinitionsCount= ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AD8));  // -> propertyDefinitionsCount
 metadataUsages          = ReadPointer(file, RvaToFileOffset(0x18D461AE0));  // -> metadataUsages
-metadataUsagesCount     = ReadPointer(file, RvaToFileOffset(0x18D461AE8));  // -> metadataUsagesCount
-imageDefinitionsCount   = ReadPointer(file, RvaToFileOffset(0x18D461AF0));  // -> imageDefinitionsCount
+metadataUsagesCount     = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AE8));  // -> metadataUsagesCount
+imageDefinitionsCount   = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AF0));  // -> imageDefinitionsCount
 ```
 
 > 위 오프셋 값은 MabinogiMobile 전용으로 하드코딩되어 있으며, Unity Il2Cpp v31 기준 `.data` 섹션에 위치한 메타데이터 포인터입니다.

--- a/Il2CppMetaForge/src/main.cpp
+++ b/Il2CppMetaForge/src/main.cpp
@@ -41,31 +41,31 @@ int main(int argc, char* argv[])
         stringTable.insert(stringTable.end(), n, n + len + 1);
     }
 
-    uint32_t typeCount = reader.ReadUInt32(gameAssembly, reader.GetTypeDefinitionsCount());
+    uint32_t typeCount = reader.GetTypeDefinitionsCount();
     std::vector<Il2CppTypeDefinition> types = reader.ReadStructArray<Il2CppTypeDefinition>(
         gameAssembly,
         reader.RvaToFileOffset(reader.GetTypeDefinitions()),
         typeCount);
 
-    uint32_t methodCount = reader.ReadUInt32(gameAssembly, reader.GetMethodDefinitionsCount());
+    uint32_t methodCount = reader.GetMethodDefinitionsCount();
     std::vector<Il2CppMethodDefinition> methods = reader.ReadStructArray<Il2CppMethodDefinition>(
         gameAssembly,
         reader.RvaToFileOffset(reader.GetMethodDefinitions()),
         methodCount);
 
-    uint32_t fieldCount = reader.ReadUInt32(gameAssembly, reader.GetFieldDefinitionsCount());
+    uint32_t fieldCount = reader.GetFieldDefinitionsCount();
     std::vector<Il2CppFieldDefinition> fields = reader.ReadStructArray<Il2CppFieldDefinition>(
         gameAssembly,
         reader.RvaToFileOffset(reader.GetFieldDefinitions()),
         fieldCount);
 
-    uint32_t propertyCount = reader.ReadUInt32(gameAssembly, reader.GetPropertyDefinitionsCount());
+    uint32_t propertyCount = reader.GetPropertyDefinitionsCount();
     std::vector<Il2CppPropertyDefinition> properties = reader.ReadStructArray<Il2CppPropertyDefinition>(
         gameAssembly,
         reader.RvaToFileOffset(reader.GetPropertyDefinitions()),
         propertyCount);
 
-    uint32_t literalCount = reader.ReadUInt32(gameAssembly, reader.GetStringLiteralTableCount());
+    uint32_t literalCount = reader.GetStringLiteralTableCount();
     std::vector<Il2CppStringLiteral> literals = reader.ReadStructArray<Il2CppStringLiteral>(
         gameAssembly,
         reader.RvaToFileOffset(reader.GetStringLiteralTable()),
@@ -79,15 +79,11 @@ int main(int argc, char* argv[])
     gameAssembly.seekg(literalDataOffset, std::ios::beg);
     gameAssembly.read(literalData.data(), literalDataSize);
 
-    std::vector<Il2CppMetadataUsage> usages;
-    uint32_t usageCount = reader.ReadUInt32(gameAssembly, reader.GetMetadataUsagesCount());
-    uintptr_t usagePtr = reader.GetMetadataUsages();
-    if (usageCount > 0)
-    {
-        Il2CppMetadataUsage usage = reader.ReadStruct<Il2CppMetadataUsage>(gameAssembly,
-            reader.RvaToFileOffset(usagePtr));
-        usages.push_back(usage);
-    }
+    uint32_t usageCount = reader.GetMetadataUsagesCount();
+    std::vector<Il2CppMetadataUsage> usages = reader.ReadStructArray<Il2CppMetadataUsage>(
+        gameAssembly,
+        reader.RvaToFileOffset(reader.GetMetadataUsages()),
+        usageCount);
 
     std::vector<Il2CppImageDefinition> images(1);
     images[0] = {};


### PR DESCRIPTION
## Summary
- store metadata table counts in `MemoryReader`
- read count values from `.data` in `LoadMetadataPointers`
- use stored counts in `main.cpp` when reading tables
- document new read logic in `MemoryReader.md`

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68669fbf25b083328215528bc3b11472