### PR TITLE
Add missing Il2Cpp structs

### DIFF
--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.h
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.h
@@ -65,6 +65,45 @@ struct Il2CppPropertyDefinition
     uint32_t token;
 };
 
+// 메서드 파라미터 정의
+struct Il2CppParameterDefinition
+{
+    uint32_t nameIndex;
+    uint32_t typeIndex;
+    uint32_t customAttributeIndex;
+};
+
+// 어셈블리 정의
+struct Il2CppAssemblyDefinition
+{
+    uint32_t imageIndex;
+    uint32_t customAttributeIndex;
+    uint32_t referencedAssemblyStart;
+    uint32_t referencedAssemblyCount;
+    uint32_t anameIndex;
+};
+
+// 제네릭 컨테이너 정보
+struct Il2CppGenericContainer
+{
+    int32_t genericParameterStart;
+    int32_t ownerIndex;
+    int32_t type_argc;
+    uint32_t is_method;
+};
+
+// 제네릭 파라미터 정보
+struct Il2CppGenericParameter
+{
+    int16_t ownerIndex;
+    uint16_t flags;
+    uint32_t nameIndex;
+    uint32_t constraintsStart;
+    uint16_t constraintsCount;
+    uint16_t pad;
+    uint32_t num;
+};
+
 struct Il2CppStringLiteral
 {
     uint32_t length;

--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.md
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.md
@@ -23,6 +23,14 @@ Il2Cpp의 구조체는 `typeDefinitions`, `methodDefinitions`, `stringLiteralTab
   - 각 함수에 대한 메타 정보를 담고 있습니다.
 - `Il2CppStringLiteral`
   - 문자열 테이블의 엔트리를 나타냅니다.
+- `Il2CppParameterDefinition`
+  - 메서드 인자의 이름과 타입 정보를 기록합니다.
+- `Il2CppAssemblyDefinition`
+  - 이미지와 참조 어셈블리 정보를 보유합니다.
+- `Il2CppGenericContainer`
+  - 제네릭 타입/메서드의 파라미터 범위를 정의합니다.
+- `Il2CppGenericParameter`
+  - 각 제네릭 파라미터의 제약 조건과 이름을 나타냅니다.
 - `Il2CppMetadataUsage`
   - 런타임 리플렉션, 메서드 바인딩 등에 사용됩니다.
 - `Il2CppImageDefinition`


### PR DESCRIPTION
## Summary
- fill in missing Il2Cpp metadata structs for parameter, assembly and generics
- document the new structs

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866d4f94f348332be819942f231a919