### PR TITLE
Add parameter and assembly metadata support

### DIFF
--- a/Il2CppMetaForge/include/MemoryReader.h
+++ b/Il2CppMetaForge/include/MemoryReader.h
@@ -25,6 +25,11 @@ public:
     uintptr_t GetPropertyDefinitions() const;
     uint32_t GetPropertyDefinitionsCount() const;
 
+    uintptr_t GetParameterDefinitions() const;
+    uint32_t GetParameterDefinitionsCount() const;
+    uintptr_t GetAssemblyDefinitions() const;
+    uint32_t GetAssemblyDefinitionsCount() const;
+
     uint32_t GetTypeDefinitionsCount() const;
     uint32_t GetMethodDefinitionsCount() const;
 
@@ -57,6 +62,12 @@ private:
     uint32_t fieldDefinitionsCount{0};
     uintptr_t propertyDefinitions{0};
     uint32_t propertyDefinitionsCount{0};
+
+    // 파라미터와 어셈블리 정의 포인터 및 개수
+    uintptr_t parameterDefinitions{0};
+    uint32_t parameterDefinitionsCount{0};
+    uintptr_t assemblyDefinitions{0};
+    uint32_t assemblyDefinitionsCount{0};
 };
 
 template <typename T>

--- a/Il2CppMetaForge/src/MemoryReader.cpp
+++ b/Il2CppMetaForge/src/MemoryReader.cpp
@@ -44,6 +44,11 @@ void MemoryReader::LoadMetadataPointers(std::ifstream& file)
     metadataUsages = ReadPointer(file, RvaToFileOffset(0x18D461AE0));
     metadataUsagesCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AE8));
     imageDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AF0));
+
+    parameterDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461AF8));
+    parameterDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461B00));
+    assemblyDefinitions = ReadPointer(file, RvaToFileOffset(0x18D461B08));
+    assemblyDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461B10));
 }
 
 uintptr_t MemoryReader::GetTypeDefinitions() const { return typeDefinitions; }
@@ -57,5 +62,9 @@ uintptr_t MemoryReader::GetFieldDefinitions() const { return fieldDefinitions; }
 uint32_t MemoryReader::GetFieldDefinitionsCount() const { return fieldDefinitionsCount; }
 uintptr_t MemoryReader::GetPropertyDefinitions() const { return propertyDefinitions; }
 uint32_t MemoryReader::GetPropertyDefinitionsCount() const { return propertyDefinitionsCount; }
+uintptr_t MemoryReader::GetParameterDefinitions() const { return parameterDefinitions; }
+uint32_t MemoryReader::GetParameterDefinitionsCount() const { return parameterDefinitionsCount; }
+uintptr_t MemoryReader::GetAssemblyDefinitions() const { return assemblyDefinitions; }
+uint32_t MemoryReader::GetAssemblyDefinitionsCount() const { return assemblyDefinitionsCount; }
 uint32_t MemoryReader::GetTypeDefinitionsCount() const { return typeDefinitionsCount; }
 uint32_t MemoryReader::GetMethodDefinitionsCount() const { return methodDefinitionsCount; }

--- a/Il2CppMetaForge/src/MemoryReader.md
+++ b/Il2CppMetaForge/src/MemoryReader.md
@@ -22,6 +22,10 @@ propertyDefinitionsCount= ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AD8
 metadataUsages          = ReadPointer(file, RvaToFileOffset(0x18D461AE0));  // -> metadataUsages
 metadataUsagesCount     = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AE8));  // -> metadataUsagesCount
 imageDefinitionsCount   = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461AF0));  // -> imageDefinitionsCount
+parameterDefinitions    = ReadPointer(file, RvaToFileOffset(0x18D461AF8));  // -> parameterDefinitions
+parameterDefinitionsCount = ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461B00));  // -> parameterDefinitionsCount
+assemblyDefinitions     = ReadPointer(file, RvaToFileOffset(0x18D461B08));  // -> assemblyDefinitions
+assemblyDefinitionsCount= ReadStruct<uint32_t>(file, RvaToFileOffset(0x18D461B10));  // -> assemblyDefinitionsCount
 ```
 
 > 위 오프셋 값은 MabinogiMobile 전용으로 하드코딩되어 있으며, Unity Il2Cpp v31 기준 `.data` 섹션에 위치한 메타데이터 포인터입니다.


### PR DESCRIPTION
## Summary
- expand MemoryReader structures to hold parameter and assembly definitions
- load new pointers in LoadMetadataPointers
- document additional offsets

## Testing
- `cd Il2CppMetaForge && ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866d794b4d483329b7fd7244d837b98