### PR TITLE
Add parameter and assembly sections to MetadataBuilder

### DIFF
--- a/Il2CppMetaForge/include/Il2CppMetadataStructs.h
+++ b/Il2CppMetaForge/include/Il2CppMetadataStructs.h
@@ -138,6 +138,12 @@ struct Il2CppGlobalMetadataHeader
 
     uint32_t imageDefinitionOffset;
     uint32_t imageDefinitionCount;
+
+    uint32_t parameterDefinitionOffset;
+    uint32_t parameterDefinitionCount;
+
+    uint32_t assemblyDefinitionOffset;
+    uint32_t assemblyDefinitionCount;
     // reserved
 };
 

--- a/Il2CppMetaForge/include/MetadataBuilder.h
+++ b/Il2CppMetaForge/include/MetadataBuilder.h
@@ -18,6 +18,8 @@ public:
     void SetStrings(const std::vector<char>& strings);
     void SetMetadataUsages(const std::vector<Il2CppMetadataUsage>& usages);
     void SetImageDefinitions(const std::vector<Il2CppImageDefinition>& images);
+    void SetParameterDefinitions(const std::vector<Il2CppParameterDefinition>& defs);
+    void SetAssemblyDefinitions(const std::vector<Il2CppAssemblyDefinition>& defs);
 
     void Build();
 
@@ -27,6 +29,8 @@ private:
     void WriteMethodDefinitions(std::ofstream& file);
     void WriteFieldDefinitions(std::ofstream& file);
     void WritePropertyDefinitions(std::ofstream& file);
+    void WriteParameterDefinitions(std::ofstream& file);
+    void WriteAssemblyDefinitions(std::ofstream& file);
     void WriteStringLiteralTable(std::ofstream& file);
     void WriteStringLiteralData(std::ofstream& file);
     void WriteStringTable(std::ofstream& file);
@@ -43,5 +47,7 @@ private:
     std::vector<char> strings;
     std::vector<Il2CppMetadataUsage> metadataUsages;
     std::vector<Il2CppImageDefinition> imageDefinitions;
+    std::vector<Il2CppParameterDefinition> parameterDefinitions;
+    std::vector<Il2CppAssemblyDefinition> assemblyDefinitions;
 };
 

--- a/Il2CppMetaForge/src/MetadataBuilder.cpp
+++ b/Il2CppMetaForge/src/MetadataBuilder.cpp
@@ -46,6 +46,16 @@ void MetadataBuilder::SetImageDefinitions(const std::vector<Il2CppImageDefinitio
     imageDefinitions = images;
 }
 
+void MetadataBuilder::SetParameterDefinitions(const std::vector<Il2CppParameterDefinition>& defs)
+{
+    parameterDefinitions = defs;
+}
+
+void MetadataBuilder::SetAssemblyDefinitions(const std::vector<Il2CppAssemblyDefinition>& defs)
+{
+    assemblyDefinitions = defs;
+}
+
 void MetadataBuilder::Build()
 {
     std::ofstream file(outputPath, std::ios::binary);
@@ -57,11 +67,13 @@ void MetadataBuilder::Build()
     WriteStringLiteralData(file);
     WriteStringTable(file);
     WriteMethodDefinitions(file);
+    WriteParameterDefinitions(file);
     WriteFieldDefinitions(file);
     WritePropertyDefinitions(file);
     WriteTypeDefinitions(file);
     WriteMetadataUsages(file);
     WriteImageDefinitions(file);
+    WriteAssemblyDefinitions(file);
 
     file.close();
 }
@@ -89,6 +101,10 @@ void MetadataBuilder::WriteMetadataHeader(std::ofstream& file)
     header.methodDefinitionCount = static_cast<uint32_t>(methodDefinitions.size());
     offset += static_cast<uint32_t>(methodDefinitions.size() * sizeof(Il2CppMethodDefinition));
 
+    header.parameterDefinitionOffset = offset;
+    header.parameterDefinitionCount = static_cast<uint32_t>(parameterDefinitions.size());
+    offset += static_cast<uint32_t>(parameterDefinitions.size() * sizeof(Il2CppParameterDefinition));
+
     header.fieldDefinitionOffset = offset;
     header.fieldDefinitionCount = static_cast<uint32_t>(fieldDefinitions.size());
     offset += static_cast<uint32_t>(fieldDefinitions.size() * sizeof(Il2CppFieldDefinition));
@@ -107,6 +123,10 @@ void MetadataBuilder::WriteMetadataHeader(std::ofstream& file)
     header.imageDefinitionOffset = offset;
     header.imageDefinitionCount = static_cast<uint32_t>(imageDefinitions.size());
     offset += static_cast<uint32_t>(imageDefinitions.size() * sizeof(Il2CppImageDefinition));
+
+    header.assemblyDefinitionOffset = offset;
+    header.assemblyDefinitionCount = static_cast<uint32_t>(assemblyDefinitions.size());
+    offset += static_cast<uint32_t>(assemblyDefinitions.size() * sizeof(Il2CppAssemblyDefinition));
 
     file.write(reinterpret_cast<const char*>(&header), sizeof(header));
 }
@@ -132,6 +152,18 @@ void MetadataBuilder::WriteFieldDefinitions(std::ofstream& file)
 void MetadataBuilder::WritePropertyDefinitions(std::ofstream& file)
 {
     for (const auto& def : propertyDefinitions)
+        file.write(reinterpret_cast<const char*>(&def), sizeof(def));
+}
+
+void MetadataBuilder::WriteParameterDefinitions(std::ofstream& file)
+{
+    for (const auto& def : parameterDefinitions)
+        file.write(reinterpret_cast<const char*>(&def), sizeof(def));
+}
+
+void MetadataBuilder::WriteAssemblyDefinitions(std::ofstream& file)
+{
+    for (const auto& def : assemblyDefinitions)
         file.write(reinterpret_cast<const char*>(&def), sizeof(def));
 }
 


### PR DESCRIPTION
## Summary
- extend `Il2CppGlobalMetadataHeader` with parameter and assembly definition offsets
- add new setters and writers in `MetadataBuilder` for those arrays
- update header offset logic and output order in `Build`
- compile with `build.sh` to verify

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866d8c9d2008332b6b91316218837f5